### PR TITLE
Containerfile.base: systemd install config

### DIFF
--- a/scripts/prepare-rootfs.sh
+++ b/scripts/prepare-rootfs.sh
@@ -42,6 +42,12 @@ cat > "/usr/lib/bootc/install/80-rootfs.toml" << 'EOF'
 type = "btrfs"
 EOF
 
+cat > "/usr/lib/bootc/install/90-install.toml" << 'EOF'
+# Need systemd as the bootloader
+[install]
+bootloader = "systemd"
+EOF
+
 cat > "/usr/lib/dracut/dracut.conf.d/20-bootc-base.conf" << 'EOF'
 # Dracut will always fail to set security.selinux xattrs at build time
 # https://github.com/dracut-ng/dracut-ng/issues/1561


### PR DESCRIPTION
`image-builder` uses the `bootc install print-configuration` to figure out various bits about the container; including any potential arguments it needs to pass to `bootc install to-filesystem`.

The current images report a `null` bootloader:

```
€ podman run quay.io/fedora-atomic-desktops-sealed/kinoite:44 bootc install print-configuration | jq .bootloader
null
```

With this drop-in the containers correctly report their bootloader:

```
€ sudo podman run localhost/kinoite:44 bootc install print-configuration | jq .bootloader
"systemd"
```

Which allows `image-builder` to set up the correct arguments to `bootc install to-filesystem`.