### PR TITLE
chore: readme/justfile fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ just generate-secure-boot-keys
 - Sign systemd-boot with the Secure Boot key:
 
 ```
-just sign-secure-boot
+just sign-systemd-boot
 ```
 
 - Build the container image with the tools to build and sign UKIs

--- a/justfile
+++ b/justfile
@@ -49,7 +49,7 @@ generate-secure-boot-keys:
     podman build --tag {{dest_registry}}/sbctl:latest --file Containerfile.sbctl
     podman run --rm -ti --security-opt=label=disable \
         --volume $(pwd):/run/src --workdir /run/src \
-        localhost/sbctl:latest create-keys --config sbctl.conf
+        {{dest_registry}}/sbctl:latest create-keys --config sbctl.conf
 
 # Sign systemd-boot with the Secure Boot key
 sign-systemd-boot:


### PR DESCRIPTION
I was building some containers from this repository and encountered two issues:

1. `sbctl` was being built as `{dest_registry}/sbctl` but used as `localhost/sbctl`.
2. A wrong justfile target was mentioned in the README.