### PR TITLE
many: `image-builder` compatibility

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,8 @@ COPY scripts /
 
 FROM $BASE as rootfs-base
 
+ARG TARGETARCH
+
 # General changes done to the base image
 RUN --mount=type=tmpfs,target=/run \
     --mount=type=tmpfs,target=/tmp \

--- a/Containerfile.base
+++ b/Containerfile.base
@@ -10,6 +10,8 @@ COPY scripts /
 
 FROM $BASE as rootfs-base
 
+ARG TARGETARCH
+
 # General changes done to the base image
 RUN --mount=type=tmpfs,target=/run \
     --mount=type=tmpfs,target=/tmp \

--- a/README.md
+++ b/README.md
@@ -147,16 +147,11 @@ Reboot to give it a try.
 
 ## How to build your own
 
-### Dependencies for building
+### Containers
 
-- podman
-- [bcvk](https://github.com/bootc-dev/bcvk) (only v0.10.0 tested as working right now)
-  - See: <https://github.com/bootc-dev/bcvk/issues/234>
-- [virt-fw-vars](https://github.com/rhuefi/qemu-ovmf-secureboot) (`python3-virt-firmware` on Fedora)
+Start with building a sealed container.
 
-We will be able to use `bcvk` more once <https://github.com/bootc-dev/bcvk/issues/237> is fixed.
-
-### Steps
+#### Steps
 
 - Generate keys for signing with Secure Boot (using [sbctl](https://github.com/foxboron/sbctl)):
 
@@ -176,6 +171,45 @@ just build-tools
 just build silverblue
 just build kinoite
 ```
+
+### Disk Images
+
+After you have the container built you can continue with turning it into a disk image. We recommend using [image-builder](https://github.com/osbuild/image-builder) as it supports many output formats but you can also use [bcvk](.
+
+There are a few ways to build disk images, either through [image-builder](https://github.com/osbuild/image-builder) or alternatively through [bcvk](https://github.com/bootc-dev/bcvk).
+
+#### `image-builder`
+
+##### Dependencies
+
+- podman
+- `image-builder`, either as a package; or as its container.
+- [virt-fw-vars](https://github.com/rhuefi/qemu-ovmf-secureboot) (`python3-virt-firmware` on Fedora)
+
+##### Steps
+
+Have your container built and available either locally or on a registry, then run `image-builder`:
+
+```
+sudo image-builder build --bootc-ref quay.io/fedora-atomic-desktops-sealed/bootc-rawhide:latest qcow2
+```
+
+Various output formats are available; amongst them `qcow2`, `ami`, `ova`, `raw` etc.
+
+Note that blueprint customizations are generally disabled for sealed container images at the moment; there is tight coupling between filesystem contents, partition layout, and the kernel arguments in the UKI. We might enable a subset of customizations [in the future](https://github.com/osbuild/image-builder/issues/2560).
+
+#### `bcvk`
+
+Using the bootc virtualization toolkit.
+
+#### Dependencies
+
+- podman
+- [bcvk](https://github.com/bootc-dev/bcvk) (only v0.10.0 tested as working right now)
+  - See: <https://github.com/bootc-dev/bcvk/issues/234>
+- [virt-fw-vars](https://github.com/rhuefi/qemu-ovmf-secureboot) (`python3-virt-firmware` on Fedora)
+
+We will be able to use `bcvk` more once <https://github.com/bootc-dev/bcvk/issues/237> is fixed.
 
 - Install the container image to a QCOW2 disk image:
 
@@ -204,7 +238,7 @@ just libvirt silverblue
 just libvirt kinoite
 ```
 
-### UKI Addons
+#### UKI Addons
 
 The kernel command line is part of the UKI and can not be changed as it is signed.
 You can build a UKI addon to add kernel command line arguments without having to rebuild the UKI.

--- a/scripts/prepare-rootfs.sh
+++ b/scripts/prepare-rootfs.sh
@@ -60,6 +60,25 @@ dnf install -y "https://kojipkgs.fedoraproject.org//packages/systemd-boot/261~rc
 # Replace the unsigned built with the signed one
 cp -a /usr/lib/systemd/boot/efi/systemd-bootx64.efi{.signed,}
 
+# prepare directory for image-builder configuration
+mkdir -p "/usr/lib/image-builder/bootc"
+
+# set up an argument for the root type UUID
+GPT_ROOT_TYPE=""
+if [[ "${TARGETARCH}" == "amd64" ]]; then
+    GPT_ROOT_TYPE="4f68bce3-e8cd-4db1-96e7-fbcaf984b709"
+elif [[ "${TARGETARCH}" == "arm64" ]]; then
+    GPT_ROOT_TYPE="b0e01050-ee5f-4390-949a-9101b17104e9"
+elif [[ "${TARGETARCH}" == "s390x" ]]; then
+    GPT_ROOT_TYPE="5eead9a9-fe09-4a1e-a1d7-520d00531306"
+elif [[ "${TARGETARCH}" == "ppc64le" ]]; then
+    GPT_ROOT_TYPE="c31c45e6-3f39-412e-80fb-4809c4980599"
+elif [[ "${TARGETARCH}" == "riscv64" ]]; then
+    GPT_ROOT_TYPE="72ec70a6-cf74-40e6-bd49-4bda08e8f224"
+else
+    exit 1
+fi
+
 if rpm -q --quiet fedora-release-identity-basic; then
 
 # bootc base iamges
@@ -69,19 +88,72 @@ cat > "/usr/lib/bootc/install/80-rootfs.toml" << 'EOF'
 type = "ext4"
 EOF
 
+# ext4 root for base
+cat > "/usr/lib/image-builder/bootc/disk.yaml" << EOF
+mount_configuration: "none"
+partition_table:
+  type: "gpt"
+  partitions:
+    - size: "2 GiB"
+      type: "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+      payload_type: "filesystem"
+      payload:
+        type: "vfat"
+        # wrong mountpoint, but isn't actually used; works around a
+        # bug in image-builder:
+        mountpoint: "/boot/efi"
+        label: "ESP"
+    - size: "3 GiB"
+      # type is architecture dependent, image-builder should auto-assign
+      # based on the architecture but for now we append based on TARGETARCH
+      type: "${GPT_ROOT_TYPE}"
+      payload_type: "filesystem"
+      payload:
+        type: "ext4"
+        label: "root"
+        mountpoint: "/"
+EOF
+
 else
 
 # All Atomic Desktops
 cat > "/usr/lib/bootc/kargs.d/10-rootfs.toml" << 'EOF'
 # Mount the root filesystem read-write
 # Enable btrfs compression
-kargs = ["rw", "rootflags=compress=zstd:1"]
+# Automatically mount the root subvolume
+kargs = ["rw", "rootflags=compress=zstd:1,subvol=root"]
 EOF
 
 cat > "/usr/lib/bootc/install/80-rootfs.toml" << 'EOF'
 # Default to btrfs
 [install.filesystem.root]
 type = "btrfs"
+EOF
+
+# btrfs root for atomic desktops
+cat > "/usr/lib/image-builder/bootc/disk.yaml" << EOF
+mount_configuration: "none"
+partition_table:
+  type: "gpt"
+  partitions:
+    - size: "2 GiB"
+      type: "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+      payload_type: "filesystem"
+      payload:
+        type: "vfat"
+        # wrong mountpoint, but isn't actually used; works around a
+        # bug in `image-builder`:
+        mountpoint: "/boot/efi"
+        label: "ESP"
+    - size: "3 GiB"
+      # type is architecture dependent, `image-builder` should auto-assign
+      # based on the architecture but for now we append based on TARGETARCH
+      type: "${GPT_ROOT_TYPE}"
+      payload_type: "btrfs"
+      payload:
+        subvolumes:
+          - name: "root"
+            mountpoint: "/"
 EOF
 
 fi
@@ -138,6 +210,7 @@ EOF
 
 # Prepare folders in /boot
 mkdir -p /boot/EFI/Linux
+
 
 ###############################################################################
 # Changes for development go here

--- a/scripts/uki.sh
+++ b/scripts/uki.sh
@@ -43,7 +43,8 @@ digest="$(bootc container compute-composefs-digest "${target}")"
 printf "composefs=${digest} rw"
 if [[ $(grep -c "zstd" "${target}/usr/lib/bootc/kargs.d/10-rootfs.toml") == 1 ]]; then
 # Enable btrfs compression for the root mount point
-printf " rootflags=compress=zstd:1"
+# Automatically mount the root subvolume
+printf " rootflags=compress=zstd:1,subvol=root"
 fi
 # Suppress console output and enable Plymouth
 printf " quiet rhgb"


### PR DESCRIPTION
This commit introduces compatibility with `image-builder` to convert sealed bootable container images into a variety of (disk) artifacts.                                                                                                                  
                                                                                                                                                                                      
Note that it *breaks* compatibility with `bcvk` at this point because `image-builder` creates, by default, a subvolume in `btrfs` layouts but it doesn't set that subvolume as the default. On the other hand `bcvk` doesn't create any subvolume. If a non-default subvolume needs to be mounted automatically it must be set default; hence the incompatibility.                                                                                                              
                                                                                                                                                                                      
The reason for this is historical, as it's the layout created by Anaconda and we wanted to keep compatibility.                                                                                                                                         
                                                                                                                                                                                      
The intent is to have `image-builder`'s `disk.yaml` grow support for selecting the default `btrfs` subvolume at which point compatibility between `bcvk` and `image-builder` is restored; though the created disk layout differs.                                                                                                                                                                       
                                                                                                                                                                                      
---

Draft because it needs some documentation updates as well.

---

The *main* reason the `Containerfile`'s need `disk.yaml`'s are because of the no-default-subvolume *and* the no-default-DPS-UUID-for-root. Both will likely also be addressed in `image-builder` at which point most of this PR should become irrelevant again.